### PR TITLE
Customize page: show calendar date if present

### DIFF
--- a/src/redis-helper.ts
+++ b/src/redis-helper.ts
@@ -5,6 +5,47 @@ import * as mbHelper        from "./mb-helper";
 import * as setlistFmHelper from "./setlist-fm-helper";
 import * as spotifyHelper   from "./spotify-helper";
 
+export async function getLineupDays(redisClient: redis.RedisClient, festivalName: string, festivalYear: number):
+    Promise<number[]> {
+    const daysPromise: Promise<number[]> = new Promise((resolve, reject) => {
+        redisClient.get(`festival:${festivalName.toLowerCase()}_${festivalYear}:days`, (err: Error, obj: string) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(JSON.parse(obj));
+            }
+        });
+    });
+
+    const days: number[] = await daysPromise;
+
+    if (days) {
+        return days;
+    }
+}
+
+export async function getLineupDayMetadata(redisClient: redis.RedisClient,
+                                           festivalName: string,
+                                           festivalYear: number,
+                                           day: number): Promise<LineupDay> {
+    const dayPromise: Promise<LineupDay> = new Promise((resolve, reject) => {
+        redisClient.hgetall(`festival:${festivalName.toLowerCase()}_${festivalYear}:days:${day}`,
+                            (err: Error, obj: any) => {
+                                if (err) {
+                                    reject(err);
+                                } else {
+                                    resolve(obj);
+                                }
+                            });
+    });
+
+    const lineupDay: LineupDay = await dayPromise;
+
+    if (lineupDay) {
+        return lineupDay;
+    }
+}
+
 export async function getLineupLastUpdatedDate(redisClient: redis.RedisClient,
                                                festivalName: string,
                                                festivalYear: number): Promise<Date> {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -182,6 +182,20 @@ interface SessionData {
     playlistUrl?: string;
 }
 
+interface LineupDay {
+    number: number
+    display_name: string
+    date: Date
+    artists: ArtistAndUri[]
+}
+
+interface FestivalLineup {
+    display_name: string
+    slug: string
+    year: number
+    days: LineupDay[]
+}
+
 // Exists to wrap an object being passed to hbs with data needed for rendering but not a part of the object itself. For
 // example, passing a genre string to customize with the session knowledge of if itshould be checked or not, state is
 // "checked" or "" and obj is the genre string

--- a/views/customize-list.handlebars
+++ b/views/customize-list.handlebars
@@ -46,9 +46,14 @@
                         {{#if (gt days.length 1)}}
                             {{#each days}}
                             <div>
-                                <label for="{{this.obj}}" class="pure-checkbox">
-                                <input class="dayCheckbox" id="{{this.obj}}" type="checkbox" value="{{this.obj}}" onchange="refreshArtistList()" {{state}}>
-                                {{this.obj}}</label>
+                                <label for="{{this.obj.number}}" class="pure-checkbox">
+                                <input class="dayCheckbox" id="{{this.obj.number}}" type="checkbox" value="{{this.obj.number}}" onchange="refreshArtistList()" {{state}}>
+                                {{#if this.obj.date}}
+                                    {{this.obj.date}}
+                                {{else}}
+                                    {{this.obj.number}}
+                                {{/if}}
+                                </label>
                             </div>
                             {{/each}}
                         {{else}}


### PR DESCRIPTION
Take advantage of the yaml format to display the calendar date (in Fri 01 Jul 2023 format) on the lineup customization page if present.

I've done various testing around different edge cases and it should work fine alongside existing lineups.

This is a very naive implementation, and it will log a warning if the number of calendar dates doesn't equal the number of days and fall back to the simple day number.

If you could re-run the cache warm script for Nos Alive 2023 that should prove it's working correctly.