### PR TITLE
Update Bonnaroo 2024 Lineup (Lineup updated March 19, 2024)

### DIFF
--- a/lineups/bonnaroo_2024.yaml
+++ b/lineups/bonnaroo_2024.yaml
@@ -26,7 +26,7 @@ days:
       - name: NEAL FRANCIS
       - name: OCIE ELLIOTT
       - name: OLIVER HELDENS
-      - name: ROISÍN MURPHY
+      - name: RÓISÍN MURPHY
       - name: SAY SHE SHE
       - name: SID SRIRAM
   - number: 2
@@ -44,14 +44,13 @@ days:
       - name: T-PAIN
       - name: SUDDEN DEATH
       - name: TV GIRL
-      - name: GARY CLARKJR.
+      - name: GARY CLARK JR.
       - name: THE MARS VOLTA
       - name: FAYE WEBSTER
       - name: KEY GLOCK
       - name: THUNDERCAT
-      - name: LOVEJOY
       - name: ISOXO
-      - name: GROUPIOVE
+      - name: GROUPLOVE
       - name: DAVID KUSHNER
       - name: THE JAPANESE HOUSE
       - name: DR. FRESCH
@@ -63,7 +62,7 @@ days:
       - name: BABY QUEEN
       - name: MDOU MOCTAR
       - name: JESSICA AUDIFFRED
-      - name: HALF MOON RUN
+      - name: MIKE
       - name: HAMDI
       - name: LYNY
   - number: 3
@@ -71,32 +70,32 @@ days:
     display_name: Day 3
     artists:
       - name: RED HOT CHILI PEPPERS
-      - name: CAGETHE ELEPHANT
+      - name: CAGE THE ELEPHANT
       - name: MELANIE MARTINEZ
       - name: CIGARETTES AFTER SEX
       - name: DIPLO
       - name: JON BATISTE
-      - name: RENEE RAPP
+      - name: RENEÉ RAPP
       - name: PARCELS
       - name: IDLES
       - name: BRITTANY HOWARD
       - name: SEAN PAUL
       - name: KNOCK2
       - name: ETHEL CAIN
-      - name: GREGORY ALAN ISAKOU
+      - name: GREGORY ALAN ISAKOV
       - name: THE TESKEY BROTHERS
-      - name: BADBADNOIGCOD
+      - name: THE GARDEN
       - name: TEEZO TOUCHDOWN
       - name: WHYTE FANG
       - name: BAKAR
       - name: D4VD
       - name: THE MAINE
-      - name: JOSIAH & THE BONNEVILLES
+      - name: JOSIAH AND THE BONNEVILLES
       - name: KASABLANCA
       - name: NEIL FRANCES
       - name: TANNER USREY
-      - name: RVAN BEATTY
-      - name: MIKE
+      - name: RYAN BEATTY
+      - name: HALF MOON RUN
       - name: TROUSDALE
       - name: VANDELUX
       - name: LOVRA
@@ -105,10 +104,10 @@ days:
     display_name: Day 4
     artists:
       - name: FRED AGAIN..
-      - name: MEGANTHEESTALTION
-      - name: JASON ISBELL AND THE 4OO UNIT
+      - name: MEGAN THEE STALLION
+      - name: JASON ISBELL AND THE 400 UNIT
       - name: TWO FRIENDS
-      - name: CARIY RAE JEPSEN
+      - name: CARLY RAE JEPSEN
       - name: JOEY BADASS
       - name: GOTH BABE
       - name: GALANTIS
@@ -119,13 +118,13 @@ days:
       - name: MILKY CHANCE
       - name: CHAPPELL ROAN
       - name: GREENSKY BLUEGRASS
-      - name: THE GARDEN
+      - name: BADBADNOTGOOD
       - name: YVES TUMOR
       - name: THE BEACHES
       - name: JAKE WESLEY ROGERS
       - name: S.G. GOODMAN
       - name: LIBIANCA
       - name: TSHA
-      - name: IRREVERSIBLE ENTANGLEMIENTS
+      - name: IRREVERSIBLE ENTANGLEMENTS
       - name: ARMAND HAMMER
       - name: VEGGI


### PR DESCRIPTION
Some artists removed from lineup, some added, some moved to different days. Corrected spelling errors.
Latest lineup can be found at: https://assets-global.website-files.com/65295330b1ddde3e7eed3313/65fe235c0e72437309d8b684_Roo24_Admat-03.19-Press-Web.png
Lineup last updated 03/19/2024