### PR TITLE
Update bonnaroo_2024.yaml

### DIFF
--- a/lineups/bonnaroo_2024.yaml
+++ b/lineups/bonnaroo_2024.yaml
@@ -49,6 +49,7 @@ days:
       - name: FAYE WEBSTER
       - name: KEY GLOCK
       - name: THUNDERCAT
+      - name: THE DRIVER ERA
       - name: ISOXO
       - name: GROUPLOVE
       - name: DAVID KUSHNER


### PR DESCRIPTION
Add THE DRIVER ERA to day 2
Updated April 11, 2024: https://assets-global.website-files.com/65295330b1ddde3e7eed3313/661d590f39ba40824d2cf7ed_Roo24_Admat-04.11-Press-Web-p-1080.png